### PR TITLE
Use registry for signed data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-client-frequency",
       "version": "0.1.0",
       "dependencies": {
-        "@frequency-chain/api-augment": "next",
+        "@frequency-chain/api-augment": "0.9.29-rc2",
         "@polkadot/api": "9.6.1",
         "@polkadot/extension-dapp": "0.44.6",
         "@polkadot/types": "9.6.1",
@@ -2126,9 +2126,9 @@
       }
     },
     "node_modules/@frequency-chain/api-augment": {
-      "version": "0.0.0-6e0b0b",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-0.0.0-6e0b0b.tgz",
-      "integrity": "sha512-zBlIPvv8F87oE7ItCoZc9xTJeanCtOtaVkr0mpOCrK9u43BrVZDMpRQ4VLXxboHGqQkMOvpiK0Sgzv9N292bAQ=="
+      "version": "0.9.29-rc2",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-0.9.29-rc2.tgz",
+      "integrity": "sha512-dMYZ/NDtUJdjnkVIFDAF9GoT8nBiID/fvZBGghjMvLAvJH6eBmL9Eyd/CgLhiMbYYLMFgvI4vj35Jl4ezwqmZg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.4",
@@ -2675,7 +2675,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@polkadot/:": {
+    "node_modules/@polkadot/api-augment": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.6.1.tgz",
       "integrity": "sha512-K2efVG15NuswLUqesaiJTtAVKKdTq1mcR/4Fw/ZCuL9vv4E8GBhvNzV0WdhSB7frEphruTgwThfav3XCTGc0uw==",
@@ -16649,9 +16649,9 @@
       }
     },
     "@frequency-chain/api-augment": {
-      "version": "0.0.0-6e0b0b",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-0.0.0-6e0b0b.tgz",
-      "integrity": "sha512-zBlIPvv8F87oE7ItCoZc9xTJeanCtOtaVkr0mpOCrK9u43BrVZDMpRQ4VLXxboHGqQkMOvpiK0Sgzv9N292bAQ=="
+      "version": "0.9.29-rc2",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-0.9.29-rc2.tgz",
+      "integrity": "sha512-dMYZ/NDtUJdjnkVIFDAF9GoT8nBiID/fvZBGghjMvLAvJH6eBmL9Eyd/CgLhiMbYYLMFgvI4vj35Jl4ezwqmZg=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@frequency-chain/api-augment": "next",
+    "@frequency-chain/api-augment": "0.9.29-rc2",
     "@polkadot/api": "9.6.1",
     "@polkadot/extension-dapp": "0.44.6",
     "@polkadot/types": "9.6.1",

--- a/src/components/CreateMessage.tsx
+++ b/src/components/CreateMessage.tsx
@@ -31,7 +31,7 @@ const CreateMessage = (props: CreateMessageProps): JSX.Element => {
 
   const handleError = async (e: Error) => {
     alert(e);
-  }
+  };
 
   const validateMessage = (): boolean => {
     console.dir(form.getFieldsValue());
@@ -43,7 +43,12 @@ const CreateMessage = (props: CreateMessageProps): JSX.Element => {
   const submitMessage = async () => {
     let avroBuffer: Buffer = staticSchema.toBuffer(form.getFieldsValue());
     console.log("avro buffer: ", avroBuffer);
-    await createMessage(avroBuffer, parseInt(props?.schema?.schema_id), () => {}, handleError);
+    await createMessage(
+      avroBuffer,
+      parseInt(props?.schema?.schema_id),
+      () => {},
+      handleError
+    );
   };
 
   return (

--- a/src/services/chain/apis/common.ts
+++ b/src/services/chain/apis/common.ts
@@ -27,33 +27,5 @@ export type DsnpErrorCallback = (error: any) => void;
  */
 export type UnsubscribeFunction = () => void;
 
-// Convert a hex string to a byte array
-export function hexToBytes(hex: string): number[] {
-  const bytes = [];
-  let c = 0;
-  for (; c < hex.length; c += 2) bytes.push(parseInt(hex.substr(c, 2), 16));
-  return bytes;
-}
-
-export function scaleEncodeDelegateData(data: DelegateData): string {
-  const expiration = bnToHex(bnToBn(data.expiration), {
-    bitLength: 32,
-    isLe: true,
-  }).substr(2);
-
-  const bitLength = data.schemaIds.length * 16 + 8;
-
-  const schemaIds = bnToHex(bnToBn(data.schemaIds.toString()), {
-    bitLength,
-    isLe: true,
-  }).substr(2);
-
-  const authorizedMsaId = bnToHex(bnToBn(data.authorizedMsaId), {
-    bitLength: 64,
-    isLe: true,
-  });
-  return authorizedMsaId + schemaIds + expiration;
-}
-
 export const getEventName = (ev: Record<string, AnyJson>): string =>
   `${ev.section}:${ev.method}`;

--- a/src/services/chain/apis/extrinsic.ts
+++ b/src/services/chain/apis/extrinsic.ts
@@ -5,12 +5,7 @@ import {
   requireGetSigner,
   requireGetWallet,
 } from "../../config";
-import {
-  DelegateData,
-  DsnpCallback,
-  DsnpErrorCallback,
-  scaleEncodeDelegateData,
-} from "./common";
+import { DelegateData, DsnpCallback, DsnpErrorCallback } from "./common";
 import { SignerPayloadRaw } from "@polkadot/types/types";
 import { KeyringPair } from "@polkadot/keyring/types";
 import {
@@ -95,11 +90,14 @@ export const createAccountViaService = async (
 
   let walletAddress = wallet.getAddress();
 
-  let encoded = scaleEncodeDelegateData(data);
+  const typedDelegateData = api.registry.createType(
+    "PalletMsaAddProvider",
+    data
+  );
 
   const result = await signRaw({
     address: walletAddress,
-    data: encoded,
+    data: typedDelegateData.toHex(),
     type: "bytes",
   } as SignerPayloadRaw);
 


### PR DESCRIPTION
Goal: Make it a lot simpler (and safer) to encode the `AddProvider` payload for signing.

- Replaces `scaleEncodeDelegateData` with `api.registry.createType("PalletMsaAddProvider", data)`
- Updated to `v0.9.29-rc2`
- Format code in `src/components/CreateMessage.tsx`